### PR TITLE
getindex as shorthand for get_elements_by_tagname

### DIFF
--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -287,6 +287,8 @@ function get_elements_by_tagname(x::XMLElement, n::AbstractString)
     return lst
 end
 
+Base.getindex(x::XMLElement, name::AbstractString) = get_elements_by_tagname(x, name)
+
 
 #######################################
 #


### PR DESCRIPTION
needs tests and docs, but this is a minimal type stable one-liner
version of allowing getindex for navigating XMLElement childrenLightXML.jl